### PR TITLE
Make s3EventRecordFromSNSWrapped public

### DIFF
--- a/s3eventutils/from_sns_event.go
+++ b/s3eventutils/from_sns_event.go
@@ -11,9 +11,9 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-// s3EventRecordFromSNSWrapper extracts the underlying s3 event record wrapped
+// S3EventRecordFromSNSWrapper extracts the underlying s3 event record wrapped
 // within the sns event.
-func s3EventRecordFromSNSWrapper(snsEvent events.SNSEvent) (*events.S3EventRecord, error) {
+func S3EventRecordFromSNSWrapper(snsEvent events.SNSEvent) (*events.S3EventRecord, error) {
 	if len(snsEvent.Records) != 1 {
 		return nil, errors.New(fmt.Sprintf("expected only 1 SNS event, received: %v", len(snsEvent.Records)))
 	}
@@ -52,7 +52,7 @@ func UriFromSNSS3EventMessage(snsEvent events.SNSEvent) (string, error) {
 // S3ObjectFromSNSS3EventMessage extracts the bucket and key from an s3 event wrapped
 // sns event.
 func S3ObjectFromSNSS3EventMessage(snsEvent events.SNSEvent) (string, string, error) {
-	record, err := s3EventRecordFromSNSWrapper(snsEvent)
+	record, err := S3EventRecordFromSNSWrapper(snsEvent)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed unwrapping s3 event record from sns")
 	}

--- a/s3eventutils/from_sns_event_test.go
+++ b/s3eventutils/from_sns_event_test.go
@@ -27,43 +27,43 @@ func createSNSRecord(message string) events.SNSEventRecord {
 	return snsEventRecord
 }
 
-func Test_s3EventRecordFromSNSWrapper(t *testing.T) {
+func Test_S3EventRecordFromSNSWrapper(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/valid_message_s3.json")
 	assert.NoError(t, err)
 
 	snsEvent := createSNSEvent(createSNSRecord(string(b)))
 
-	r, err := s3EventRecordFromSNSWrapper(snsEvent)
+	r, err := S3EventRecordFromSNSWrapper(snsEvent)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "bktname", r.S3.Bucket.Name)
 	assert.Equal(t, "some/file/in/s3.txt", r.S3.Object.Key)
 }
 
-func Test_s3EventRecordFromSNSWrapper_error_sns_record_count(t *testing.T) {
+func Test_S3EventRecordFromSNSWrapper_error_sns_record_count(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/valid_message_s3.json")
 	assert.NoError(t, err)
 
 	snsEvent := createSNSEvent(createSNSRecord(string(b)), createSNSRecord(string(b)))
 
-	_, err = s3EventRecordFromSNSWrapper(snsEvent)
+	_, err = S3EventRecordFromSNSWrapper(snsEvent)
 	assert.Error(t, err)
 }
 
-func Test_s3EventRecordFromSNSWrapper_error_invalid_message(t *testing.T) {
+func Test_S3EventRecordFromSNSWrapper_error_invalid_message(t *testing.T) {
 	snsEvent := createSNSEvent(createSNSRecord("not json"))
 
-	_, err := s3EventRecordFromSNSWrapper(snsEvent)
+	_, err := S3EventRecordFromSNSWrapper(snsEvent)
 	assert.Error(t, err)
 }
 
-func Test_s3EventRecordFromSNSWrapper_error_s3_Record_count(t *testing.T) {
+func Test_S3EventRecordFromSNSWrapper_error_s3_Record_count(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/invalid_message_s3_count.json")
 	assert.NoError(t, err)
 
 	snsEvent := createSNSEvent(createSNSRecord(string(b)))
 
-	_, err = s3EventRecordFromSNSWrapper(snsEvent)
+	_, err = S3EventRecordFromSNSWrapper(snsEvent)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
This is a useful function that should be available to users of the library.